### PR TITLE
Change error inheritance

### DIFF
--- a/lib/app_annie.rb
+++ b/lib/app_annie.rb
@@ -54,10 +54,11 @@ module AppAnnie
     end
   end
 
-  class Unauthorized < Exception; end
-  class RateLimitExceeded < Exception; end
-  class ServerError < Exception; end
-  class ServerUnavailable < Exception; end
-  class BadResponse < Exception; end
+  class AppAnnieError < RuntimeError; end
+  class Unauthorized < AppAnnieError; end
+  class RateLimitExceeded < AppAnnieError; end
+  class ServerError < AppAnnieError; end
+  class ServerUnavailable < AppAnnieError; end
+  class BadResponse < AppAnnieError; end
 
 end

--- a/lib/app_annie/meta_data.rb
+++ b/lib/app_annie/meta_data.rb
@@ -1,6 +1,6 @@
 module AppAnnie
   class MetaData
-    API_ROOT = "/v1.2/".freeze
+    API_ROOT = "/v1.2".freeze
 
     def self.translate_ids(opts)
       [:market, :package_codes].each do |key|


### PR DESCRIPTION
The custom errors are inheriting directly from `Exception`, which has a
side effect of them not being rescue-able with Rails' `rescue_from`.

The Ruby docs also have this to say:

> It is recommended that a library should have one subclass of
> StandardError or RuntimeError and have specific exception types
> inherit from it.